### PR TITLE
feat: implement root() function to find project root

### DIFF
--- a/R/root.R
+++ b/R/root.R
@@ -1,0 +1,36 @@
+#' Find project root directory
+#'
+#' Find the project root by locating the nearest _bakepipe.R file,
+#' searching upward from the current working directory.
+#'
+#' @return Character string with the absolute path to the project root
+#' @export
+#' @examples
+#' \dontrun{
+#' # Get the project root directory
+#' project_root <- root()
+#' }
+root <- function() {
+  current_dir <- getwd()
+  
+  # Start from current directory and walk up the tree
+  while (TRUE) {
+    # Check if _bakepipe.R exists in current directory
+    bakepipe_path <- file.path(current_dir, "_bakepipe.R")
+    
+    if (file.exists(bakepipe_path)) {
+      return(normalizePath(current_dir))
+    }
+    
+    # Get parent directory
+    parent_dir <- dirname(current_dir)
+    
+    # If we've reached the filesystem root (parent is same as current)
+    if (parent_dir == current_dir) {
+      stop("Could not find _bakepipe.R in any parent directory")
+    }
+    
+    # Move up one level
+    current_dir <- parent_dir
+  }
+}

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -1,0 +1,113 @@
+test_that("root() finds _bakepipe.R in current directory", {
+  # Create a temporary directory structure
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+  
+  # Setup: Create a temporary project directory with _bakepipe.R
+  project_dir <- file.path(temp_dir, "test_project")
+  dir.create(project_dir, recursive = TRUE)
+  
+  # Create _bakepipe.R in the project root
+  bakepipe_file <- file.path(project_dir, "_bakepipe.R")
+  file.create(bakepipe_file)
+  
+  # Change to project directory
+  setwd(project_dir)
+  
+  # Test: root() should return the current directory
+  expect_equal(root(), normalizePath(project_dir))
+  
+  # Cleanup
+  setwd(old_wd)
+  unlink(project_dir, recursive = TRUE)
+})
+
+test_that("root() finds _bakepipe.R in parent directory", {
+  # Create a temporary directory structure
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+  
+  # Setup: Create nested directory structure
+  project_dir <- file.path(temp_dir, "test_project")
+  sub_dir <- file.path(project_dir, "subdir")
+  dir.create(sub_dir, recursive = TRUE)
+  
+  # Create _bakepipe.R in the project root
+  bakepipe_file <- file.path(project_dir, "_bakepipe.R")
+  file.create(bakepipe_file)
+  
+  # Change to subdirectory
+  setwd(sub_dir)
+  
+  # Test: root() should return the parent directory containing _bakepipe.R
+  expect_equal(root(), normalizePath(project_dir))
+  
+  # Cleanup
+  setwd(old_wd)
+  unlink(project_dir, recursive = TRUE)
+})
+
+test_that("root() finds _bakepipe.R in grandparent directory", {
+  # Create a temporary directory structure
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+  
+  # Setup: Create deeply nested directory structure
+  project_dir <- file.path(temp_dir, "test_project")
+  sub_dir <- file.path(project_dir, "subdir")
+  sub_sub_dir <- file.path(sub_dir, "subsubdir")
+  dir.create(sub_sub_dir, recursive = TRUE)
+  
+  # Create _bakepipe.R in the project root
+  bakepipe_file <- file.path(project_dir, "_bakepipe.R")
+  file.create(bakepipe_file)
+  
+  # Change to deeply nested subdirectory
+  setwd(sub_sub_dir)
+  
+  # Test: root() should return the grandparent directory containing _bakepipe.R
+  expect_equal(root(), normalizePath(project_dir))
+  
+  # Cleanup
+  setwd(old_wd)
+  unlink(project_dir, recursive = TRUE)
+})
+
+test_that("root() throws error when no _bakepipe.R found", {
+  # Create a temporary directory structure without _bakepipe.R
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+  
+  # Setup: Create directory without _bakepipe.R
+  test_dir <- file.path(temp_dir, "no_bakepipe")
+  dir.create(test_dir, recursive = TRUE)
+  
+  # Change to directory without _bakepipe.R
+  setwd(test_dir)
+  
+  # Test: root() should throw an error
+  expect_error(root(), "Could not find _bakepipe.R")
+  
+  # Cleanup
+  setwd(old_wd)
+  unlink(test_dir, recursive = TRUE)
+})
+
+test_that("root() stops at filesystem root", {
+  # This test ensures we don't search beyond the filesystem root
+  # We'll mock this by testing the search stops appropriately
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+  
+  # Create a directory structure without _bakepipe.R
+  test_dir <- file.path(temp_dir, "no_root_marker")
+  dir.create(test_dir, recursive = TRUE)
+  setwd(test_dir)
+  
+  # Should error because no _bakepipe.R found
+  expect_error(root(), "Could not find _bakepipe.R")
+  
+  # Cleanup
+  setwd(old_wd)
+  unlink(test_dir, recursive = TRUE)
+})


### PR DESCRIPTION
## Summary
- Implement root() function that finds project root by locating nearest _bakepipe.R file
- Add comprehensive tests covering directory traversal, error handling, and edge cases

## Test plan
- [x] Test finds _bakepipe.R in current directory
- [x] Test finds _bakepipe.R in parent directory  
- [x] Test finds _bakepipe.R in grandparent directory
- [x] Test throws error when no _bakepipe.R found
- [x] Test stops at filesystem root appropriately
- [x] All tests pass

Closes #8 

🤖 Generated with [Claude Code](https://claude.ai/code)