### PR TITLE
feat: implement scripts() function to find all R files

### DIFF
--- a/R/scripts.R
+++ b/R/scripts.R
@@ -1,0 +1,30 @@
+#' Find all R scripts in project
+#'
+#' Returns a vector with paths to all .R scripts in or below the project root.
+#' The project root is determined by bakepipe::root().
+#'
+#' @return Character vector of absolute paths to .R files
+#' @export
+#' @examples
+#' \dontrun{
+#' # Get all R scripts in the project
+#' all_scripts <- scripts()
+#' }
+scripts <- function() {
+  project_root <- root()
+
+  # Find all .R files recursively from the project root
+  r_files <- list.files(
+    path = project_root,
+    pattern = "\\.R$",
+    recursive = TRUE,
+    full.names = TRUE,
+    ignore.case = TRUE
+  )
+
+  # Filter out _bakepipe.R file
+  r_files <- r_files[!grepl("_bakepipe\\.R$", r_files, ignore.case = TRUE)]
+
+  # Return normalized paths
+  normalizePath(r_files)
+}

--- a/tests/testthat/test-scripts.R
+++ b/tests/testthat/test-scripts.R
@@ -1,0 +1,178 @@
+test_that("scripts() finds .R files in project root", {
+  # Create a temporary directory structure
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+
+  # Setup: Create a temporary project directory with _bakepipe.R
+  project_dir <- file.path(temp_dir, "test_project")
+  dir.create(project_dir, recursive = TRUE)
+
+  # Create _bakepipe.R in the project root
+  bakepipe_file <- file.path(project_dir, "_bakepipe.R")
+  file.create(bakepipe_file)
+
+  # Create some R files in the project root
+  script1 <- file.path(project_dir, "analysis.R")
+  script2 <- file.path(project_dir, "helpers.R")
+  file.create(script1)
+  file.create(script2)
+
+  # Change to project directory
+  setwd(project_dir)
+
+  # Test: scripts() should find the R files
+  result <- scripts()
+  expect_type(result, "character")
+  expect_length(result, 2)
+  expect_true(normalizePath(script1) %in% result)
+  expect_true(normalizePath(script2) %in% result)
+
+  # Cleanup
+  setwd(old_wd)
+  unlink(project_dir, recursive = TRUE)
+})
+
+test_that("scripts() finds .R files recursively in subdirectories", {
+  # Create a temporary directory structure
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+
+  # Setup: Create nested directory structure
+  project_dir <- file.path(temp_dir, "test_project")
+  sub_dir <- file.path(project_dir, "scripts")
+  sub_sub_dir <- file.path(sub_dir, "utils")
+  dir.create(sub_sub_dir, recursive = TRUE)
+
+  # Create _bakepipe.R in the project root
+  bakepipe_file <- file.path(project_dir, "_bakepipe.R")
+  file.create(bakepipe_file)
+
+  # Create R files at different levels
+  root_script <- file.path(project_dir, "main.R")
+  sub_script <- file.path(sub_dir, "process.R")
+  deep_script <- file.path(sub_sub_dir, "helpers.R")
+  file.create(root_script)
+  file.create(sub_script)
+  file.create(deep_script)
+
+  # Create a non-R file to ensure it's ignored
+  txt_file <- file.path(project_dir, "readme.txt")
+  file.create(txt_file)
+
+  # Change to project directory
+  setwd(project_dir)
+
+  # Test: scripts() should find all R files recursively
+  result <- scripts()
+  expect_type(result, "character")
+  expect_length(result, 3)
+  expect_true(normalizePath(root_script) %in% result)
+  expect_true(normalizePath(sub_script) %in% result)
+  expect_true(normalizePath(deep_script) %in% result)
+  expect_false(normalizePath(txt_file) %in% result)
+
+  # Cleanup
+  setwd(old_wd)
+  unlink(project_dir, recursive = TRUE)
+})
+
+test_that("scripts() handles case-insensitive .R extensions", {
+  # Create a temporary directory structure
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+
+  # Setup: Create a temporary project directory
+  project_dir <- file.path(temp_dir, "test_project")
+  dir.create(project_dir, recursive = TRUE)
+
+  # Create _bakepipe.R in the project root
+  bakepipe_file <- file.path(project_dir, "_bakepipe.R")
+  file.create(bakepipe_file)
+
+  # Create R files with different case extensions
+  script_lower <- file.path(project_dir, "script1.r")
+  script_upper <- file.path(project_dir, "script2.R")
+  file.create(script_lower)
+  file.create(script_upper)
+
+  # Change to project directory
+  setwd(project_dir)
+
+  # Test: scripts() should find both .r and .R files
+  result <- scripts()
+  expect_type(result, "character")
+  expect_length(result, 2)
+  expect_true(normalizePath(script_lower) %in% result)
+  expect_true(normalizePath(script_upper) %in% result)
+
+  # Cleanup
+  setwd(old_wd)
+  unlink(project_dir, recursive = TRUE)
+})
+
+test_that("scripts() returns empty vector when no .R files found", {
+  # Create a temporary directory structure
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+
+  # Setup: Create a project directory with only non-R files
+  project_dir <- file.path(temp_dir, "test_project")
+  dir.create(project_dir, recursive = TRUE)
+
+  # Create _bakepipe.R in the project root
+  bakepipe_file <- file.path(project_dir, "_bakepipe.R")
+  file.create(bakepipe_file)
+
+  # Create non-R files
+  txt_file <- file.path(project_dir, "readme.txt")
+  csv_file <- file.path(project_dir, "data.csv")
+  file.create(txt_file)
+  file.create(csv_file)
+
+  # Change to project directory
+  setwd(project_dir)
+
+  # Test: scripts() should return empty character vector
+  result <- scripts()
+  expect_type(result, "character")
+  expect_length(result, 0)
+
+  # Cleanup
+  setwd(old_wd)
+  unlink(project_dir, recursive = TRUE)
+})
+
+test_that("scripts() works from subdirectory", {
+  # Create a temporary directory structure
+  temp_dir <- tempdir()
+  old_wd <- getwd()
+
+  # Setup: Create nested directory structure
+  project_dir <- file.path(temp_dir, "test_project")
+  sub_dir <- file.path(project_dir, "analysis")
+  dir.create(sub_dir, recursive = TRUE)
+
+  # Create _bakepipe.R in the project root
+  bakepipe_file <- file.path(project_dir, "_bakepipe.R")
+  file.create(bakepipe_file)
+
+  # Create R files
+  root_script <- file.path(project_dir, "main.R")
+  sub_script <- file.path(sub_dir, "analyze.R")
+  file.create(root_script)
+  file.create(sub_script)
+
+  # Change to subdirectory
+  setwd(sub_dir)
+
+  # Test: scripts() should still find all R files in project
+  result <- scripts()
+  expect_type(result, "character")
+  expect_length(result, 2)
+  expect_true(normalizePath(root_script) %in% result)
+  expect_true(normalizePath(sub_script) %in% result)
+
+  # Cleanup
+  setwd(old_wd)
+  unlink(project_dir, recursive = TRUE)
+})


### PR DESCRIPTION
## Summary
- Implement `bakepipe::scripts()` function that returns paths to all .R scripts in or below `bakepipe::root()`
- Function recursively searches project directory and excludes `_bakepipe.R` configuration file
- Comprehensive test suite covering various scenarios including edge cases

## Test plan
- [x] Test finds .R files in project root
- [x] Test finds .R files recursively in subdirectories  
- [x] Test handles case-insensitive .R extensions (.r and .R)
- [x] Test returns empty vector when no .R files found
- [x] Test works correctly from any subdirectory within project
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)